### PR TITLE
[PATCH] Fix status name by activity type

### DIFF
--- a/src/background/controller/active.ts
+++ b/src/background/controller/active.ts
@@ -4,7 +4,7 @@
 // the given timestamp and focused active tab, and saves it to the database using
 // setActiveTabRecord function.
 import { Tab } from '../../shared/browser-api.types';
-import { TimelineRecord } from '../../shared/db/types';
+import { TimelineRecord, TimelineRecordStatus } from '../../shared/db/types';
 import { getIsoDate } from '../../shared/utils/dates-helper';
 import { getHostNameFromUrl } from '../../shared/utils/url';
 import { getActiveTabRecord, setActiveTabRecord } from '../tables/state';
@@ -35,6 +35,7 @@ export class ActiveTimelineRecordDao {
 export async function createNewActiveRecord(
   timestamp: number,
   focusedActiveTab: Tab,
+  status: TimelineRecordStatus,
 ) {
   if (!focusedActiveTab.id) {
     return;
@@ -51,7 +52,7 @@ export async function createNewActiveRecord(
     favIconUrl,
     hostname,
     secure: focusedActiveTab.incognito,
-    status: focusedActiveTab.status,
+    status,
     tabId: focusedActiveTab.id,
     url,
   });

--- a/src/background/services/stats.ts
+++ b/src/background/services/stats.ts
@@ -99,7 +99,7 @@ const transformToWebActivityLog = (record: TimelineRecord): WebActivityLog => {
   return {
     Duration: difference.seconds as number,
     From: startTime,
-    Status: record.status as string,
+    Status: record.status,
   };
 };
 

--- a/src/devtools.index.ts
+++ b/src/devtools.index.ts
@@ -1,0 +1,10 @@
+(() => {
+  const backgroundPageConnection = chrome.runtime.connect({
+    name: 'devtools-page',
+  });
+
+  backgroundPageConnection.postMessage({
+    status: 'debugging-started',
+    tabId: chrome.devtools.inspectedWindow.tabId,
+  });
+})();

--- a/src/shared/db/types.ts
+++ b/src/shared/db/types.ts
@@ -19,6 +19,8 @@ export interface WebActivityRecord {
   Url: string;
 }
 
+export type TimelineRecordStatus = 'navigation' | 'debugging' | 'debugger';
+
 export interface TimelineRecord {
   tabId: number;
   url: string;
@@ -26,8 +28,8 @@ export interface TimelineRecord {
   docTitle: string;
   favIconUrl: string | undefined;
   date: string;
+  status: TimelineRecordStatus;
   secure: boolean;
-  status?: string;
   activityPeriodStart: number;
   activityPeriodEnd: number;
 }
@@ -38,6 +40,13 @@ export type ActiveTabState = {
   focusedWindowId?: number;
   idleState?: IdleState;
 };
+
+export interface DebugTab {
+  tabId?: number;
+  title?: string;
+  url?: string;
+  windowId: number;
+}
 
 export interface LogMessage {
   message: string;

--- a/static/devtools.html
+++ b/static/devtools.html
@@ -1,0 +1,1 @@
+<script src="./devtools.bundle.js"></script>

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Codealike",
   "manifest_version": 3,
+  "devtools_page": "devtools.html",
   "action": {
     "default_popup": "popup.html",
     "default_title": "Codealike",
@@ -29,8 +30,10 @@
     "idle",
     "storage",
     "tabs",
+    "activeTab",
     "alarms",
-    "webNavigation"
+    "webNavigation",
+    "debugger"
   ],
   "host_permissions": [
     "http://*/*",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = (env, argv) => ({
   entry: {
     background: './src/background.index.ts',
     content: './src/content.index.ts',
+    devtools: './src/devtools.index.ts',
     popup: './src/popup.index.tsx',
   },
   module: {


### PR DESCRIPTION
Update the status of the activity by one of the options:
- `navigation` => when the user opens a tab and navigates to an aleatory website;
- `debugging` => similar to `navigation`, but the user opens a developer tool for debug purposes
- `debugger` => when debugging the developer tool itself

This PR includes a fake developer tool to identify when a user opens the developer tool in a specific tab, then all activities coming from this tab are flagged as a `debugging` activity instead of the normal one `navigation`.

Updating the status Codealike already groups the activities and we show the time spent in each activity: 👇🏻 

![Screenshot 2023-03-15 at 5 25 29 PM](https://user-images.githubusercontent.com/35741698/225478807-67726d45-36b0-46d8-b4a0-b997aa8ced1b.png)

