### PR TITLE
#30: fixed the multiple auth api calls issue

### DIFF
--- a/src/popup/components/UserTokenSetting/UserTokenSetting.tsx
+++ b/src/popup/components/UserTokenSetting/UserTokenSetting.tsx
@@ -75,7 +75,15 @@ export const UserTokenSetting: React.FC = () => {
 
   React.useEffect(() => {
     (async function () {
-      authorizeUserToken();
+      const { connectionStatus } = settings;
+
+      if (connectionStatus === ConnectionStatus.Connected) {
+        setState({
+          ...state,
+          connectionStatus: ConnectionStatus.Connected,
+          status: 'Codealike is connected',
+        });
+      }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
Issue: #30 

Changes:
- Previously the Codealike Authorise API was getting called everytime the settings page is visited to ensure that the user is connect. But we already maintain a status for account connection called ConnectionStatus in the settings. So instead of calling the Auth API everytime, this status flag is now getting used to determine whether the user is connected or not.