### PR TITLE
ui improvements

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -63,7 +63,7 @@ export const PopupApp: React.FC = () => {
               activePage.tab === tab &&
                 'bg-neutral-300 text-neutral-800 dark:bg-neutral-900 dark:text-neutral-200',
               activePage.tab !== tab &&
-                'hover:bg-neutral-100 text-neutral-400 dark:hover:bg-neutral-900 dark:text-neutral-400',
+                'hover:bg-neutral-100 text-[#737373] dark:hover:bg-neutral-900 dark:text-neutral-400',
               tab === Pages.Preferences && 'max-w-[75px]',
             )}
             key={tab}
@@ -83,9 +83,9 @@ export const PopupApp: React.FC = () => {
   return (
     <PopupContextProvider>
       <div className="flex flex-col p-2 pt-4 dark:bg-neutral-900">
-        <div className="text-orange-500 p-2 border-none bg-slate-200 dark:bg-slate-800 tab-body-shadow dark:dark-tab-body-shadow">
+        <div className="text-orange-500 p-2 border-none bg-slate-200 dark:bg-slate-800 tab-body-shadow dark:dark-tab-body-shadow flex">
           <img src="./icons/icon-16.png"></img>
-          Codealike
+          <span className='font-semibold px-2'>Codealike</span>
         </div>
         <Panel className="flex gap-2 p-2 font-semibold">{tabs}</Panel>
         <Panel className="p-2 border-none bg-slate-200 dark:bg-slate-800 tab-body-shadow dark:dark-tab-body-shadow">

--- a/src/popup/components/ActivityDatePicker/index.tsx
+++ b/src/popup/components/ActivityDatePicker/index.tsx
@@ -38,6 +38,7 @@ export const ActivityDatePicker: React.FC<ActivityDatePickerProps> = ({
       <Button
         buttonType={ButtonType.Secondary}
         onClick={() => onDateChangeButtonClick(-1)}
+        className='px-4'
       >
         <Icon className="m-0 flex" type={IconType.LeftArrow} />
       </Button>
@@ -50,6 +51,7 @@ export const ActivityDatePicker: React.FC<ActivityDatePickerProps> = ({
       <Button
         buttonType={ButtonType.Secondary}
         onClick={() => onDateChangeButtonClick(1)}
+        className='px-4'
       >
         <Icon className="m-0 flex" type={IconType.RightArrow} />
       </Button>

--- a/src/popup/components/ActivityPageDailyActivityTab/ActivityPageDailyActivityTab.tsx
+++ b/src/popup/components/ActivityPageDailyActivityTab/ActivityPageDailyActivityTab.tsx
@@ -67,6 +67,7 @@ export const DailyActivityTab: React.FC<DailyActivityTabProps> = ({
           title="Activity Timeline"
           activityTimeline={activityTimeline}
           filteredHostname={filteredHostname}
+          description="Your web activity timeline."
         />
       </div>
       <WebsiteActivityTable

--- a/src/popup/components/ActivityPageMonthlyActivityTab/ActivityPageMonthlyActivityTab.tsx
+++ b/src/popup/components/ActivityPageMonthlyActivityTab/ActivityPageMonthlyActivityTab.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+
+import { TimeStore } from '../../hooks/useTimeStore';
+import { get30DaysPriorDate, getIsoDate } from '../../../shared/utils/dates-helper';
+
+import { TimeUsagePanel } from '../DailyTimeUsage/DailyTimeUsage';
+import { WebsiteActivityTable } from '../WebsiteActivityTable/WebsiteActivityTable';
+import { ActivityPageMonthlyActivityTabProps } from './types';
+import { getTotalMonthlyActivity } from '../../selectors/get-total-monthly-activity';
+import { MonthlyWebsiteActivityChart } from '../MonthlyWebsiteActivityChart/MonthlyWebsiteActivityChart';
+
+
+export const ActivityPageMonthlyActivityTab: React.FC<ActivityPageMonthlyActivityTabProps> =
+  ({ store, sundayDate }) => {
+    const [pickedDomain, setPickedDomain] = React.useState<null | string>(null);
+    const scrollToRef = React.useRef<HTMLDivElement | null>(null);
+
+    const handleDomainRowClick = React.useCallback((domain: string) => {
+      setPickedDomain(domain);
+      scrollToRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, []);
+
+    const allMonthlyActivity = React.useMemo(
+      () =>
+        get30DaysPriorDate(sundayDate).reduce((acc, date) => {
+          const isoDate = getIsoDate(date);
+          acc[isoDate] = store[isoDate] || {};
+
+          return acc;
+        }, {} as TimeStore),
+      [store, sundayDate]
+    );
+
+    const filteredWebsiteMonthActivity = React.useMemo(() => {
+      if (pickedDomain === null) {
+        return allMonthlyActivity;
+      }
+
+      return Object.entries(allMonthlyActivity).reduce(
+        (acc, [date, dateWebsitesUsage]) => {
+          acc[date] = {
+            [pickedDomain]: dateWebsitesUsage[pickedDomain] || 0,
+          };
+
+          return acc;
+        },
+        {} as typeof allMonthlyActivity
+      );
+    }, [allMonthlyActivity, pickedDomain]);
+
+    const totalWebsiteMonthlyActivity = React.useMemo(
+      () =>
+        Object.values(allMonthlyActivity).reduce((acc, dailyUsage) => {
+          Object.entries(dailyUsage).forEach(([key, value]) => {
+            acc[key] ??= 0;
+            acc[key] += value;
+          });
+
+          return acc;
+        }, {} as Record<string, number>),
+      [allMonthlyActivity]
+    );
+
+    const averageMonthlyActivity = React.useMemo(() => {
+      const averageMonthly =
+        getTotalMonthlyActivity(filteredWebsiteMonthActivity, sundayDate) / 7;
+      return averageMonthly;
+    }, [filteredWebsiteMonthActivity, sundayDate]);
+
+    const presentedPickedDomain = pickedDomain ?? 'All Websites';
+
+    return (
+      <div>
+        <TimeUsagePanel
+          title="Average Daily Activity"
+          time={averageMonthlyActivity}
+        />
+        <div ref={scrollToRef}>
+          <MonthlyWebsiteActivityChart
+            store={filteredWebsiteMonthActivity}
+            sundayDate={sundayDate}
+            presentChartTitle={() =>
+              `Activity on ${presentedPickedDomain} per day`
+            }
+          />
+        </div>
+        <WebsiteActivityTable
+          websiteTimeMap={totalWebsiteMonthlyActivity}
+          title={'Websites This Month'}
+          onDomainRowClicked={handleDomainRowClick}
+        />
+      </div>
+    );
+  };

--- a/src/popup/components/ActivityPageMonthlyActivityTab/types.ts
+++ b/src/popup/components/ActivityPageMonthlyActivityTab/types.ts
@@ -1,0 +1,6 @@
+import { TimeStore } from '../../hooks/useTimeStore';
+
+export interface ActivityPageMonthlyActivityTabProps {
+  store: TimeStore;
+  sundayDate: Date;
+}

--- a/src/popup/components/GeneralTimeline/GeneralTimeline.tsx
+++ b/src/popup/components/GeneralTimeline/GeneralTimeline.tsx
@@ -13,6 +13,7 @@ const GeneralTimelineFC: React.FC<GeneralTimelineProps> = ({
   activityTimeline,
   title,
   emptyHoursMarginCount = 2,
+  description,
 }) => {
   return (
     <Panel>
@@ -20,6 +21,7 @@ const GeneralTimelineFC: React.FC<GeneralTimelineProps> = ({
         <Icon type={IconType.TimePast} />
         {title}
         {filteredHostname ? ` On ${filteredHostname}` : ''}
+        <span className='text-xs'> ({description})</span>
       </PanelHeader>
       <PanelBody
         className={twMerge(

--- a/src/popup/components/GeneralTimeline/types.ts
+++ b/src/popup/components/GeneralTimeline/types.ts
@@ -5,4 +5,5 @@ export interface GeneralTimelineProps {
   emptyHoursMarginCount?: number;
   filteredHostname?: string | null;
   activityTimeline: TimelineRecord[];
+  description: string;
 }

--- a/src/popup/components/GithubCalendarWrapper/GithubCalendarWrapper.tsx
+++ b/src/popup/components/GithubCalendarWrapper/GithubCalendarWrapper.tsx
@@ -6,12 +6,13 @@ import { debounce } from 'throttle-debounce';
 import { getIsoDate } from '../../../shared/utils/dates-helper';
 
 import { GithubCalendarProps } from './types';
+import { getAppTheme } from '../../hooks/useTheme';
 
-const INACTIVE_DAY_COLOR = '#cccccc';
-const LOW_ACTIVITY_DAY_COLOR = '#839dde';
-const MEDIUM_ACTIVITY_DAY_COLOR = '#4b76e3';
-const HIGH_ACTIVITY_DAY_COLOR = '#103ba6';
-const COLORS = [
+let INACTIVE_DAY_COLOR = '#444444';
+let LOW_ACTIVITY_DAY_COLOR = '#114A74';
+let MEDIUM_ACTIVITY_DAY_COLOR = '#0073C1';
+let HIGH_ACTIVITY_DAY_COLOR = '#5BC0FB';
+let COLORS = [
   INACTIVE_DAY_COLOR,
   LOW_ACTIVITY_DAY_COLOR,
   MEDIUM_ACTIVITY_DAY_COLOR,
@@ -56,6 +57,36 @@ export const GithubCalendarWrapper: React.FC<GithubCalendarProps> = ({
 }) => {
   const calendarRef = React.useRef<HTMLDivElement>(null);
 
+  const theme = getAppTheme();
+
+  if (theme === 'light') {
+    INACTIVE_DAY_COLOR = '#F0F0F0';
+    LOW_ACTIVITY_DAY_COLOR = '#FFE0B2';
+    MEDIUM_ACTIVITY_DAY_COLOR = '#FFB74D';
+    HIGH_ACTIVITY_DAY_COLOR = '#FFA744';
+
+    COLORS = [
+      INACTIVE_DAY_COLOR,
+      LOW_ACTIVITY_DAY_COLOR,
+      MEDIUM_ACTIVITY_DAY_COLOR,
+      HIGH_ACTIVITY_DAY_COLOR,
+    ]
+  }
+
+  if (theme === 'dark') {
+    INACTIVE_DAY_COLOR = '#2C2C2C';
+    LOW_ACTIVITY_DAY_COLOR = '#5C3B1A';
+    MEDIUM_ACTIVITY_DAY_COLOR = '#AB6C33';
+    HIGH_ACTIVITY_DAY_COLOR = '#FFA744';
+
+    COLORS = [
+      INACTIVE_DAY_COLOR,
+      LOW_ACTIVITY_DAY_COLOR,
+      MEDIUM_ACTIVITY_DAY_COLOR,
+      HIGH_ACTIVITY_DAY_COLOR,
+    ]
+  }
+
   React.useEffect(() => {
     if (!calendarRef.current) {
       return;
@@ -82,6 +113,14 @@ export const GithubCalendarWrapper: React.FC<GithubCalendarProps> = ({
     <div className="calendar" ref={calendarRef} onClick={handleDateClick}>
       {/* @ts-expect-error -- expected, this element does have props */}
       <Calendar values={activity} panelColors={COLORS} />
+      <div className="flex items-center justify-end gap-1">
+        <span className="text-gray-400">Less</span>
+        <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: INACTIVE_DAY_COLOR }} />
+        <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: LOW_ACTIVITY_DAY_COLOR }} />
+        <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: MEDIUM_ACTIVITY_DAY_COLOR }} />
+        <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: HIGH_ACTIVITY_DAY_COLOR }} />
+        <span className="text-gray-400">More</span>
+      </div>
       <ReactTooltip
         id={REACT_TOOLTIP_ID}
         delayShow={REACT_TOOLTIP_SHOW_DELAY_MS}

--- a/src/popup/components/IgnoredDomainsSetting/IgnoredDomainSetting.tsx
+++ b/src/popup/components/IgnoredDomainsSetting/IgnoredDomainSetting.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { twMerge } from 'tailwind-merge';
 
 import { Button, ButtonType } from '../../../blocks/Button';
 import { Icon, IconType } from '../../../blocks/Icon';
-import { Input } from '../../../blocks/Input';
+import { TextArea } from '../../../blocks/Input';
 import { PanelBody } from '../../../blocks/Panel';
 import { assertDomainIsValid } from '../../../shared/utils/domains';
 import { usePopupContext } from '../../hooks/PopupContext';
@@ -14,27 +13,46 @@ export const IgnoredDomainSetting: React.FC = () => {
     settings.ignoredHosts
   );
   const [domainToIgnore, setDomainToIgnore] = React.useState<string>('');
-  const [isDomainsListExpanded, setDomainsListExpanded] =
-    React.useState<boolean>(false);
+  const [state, setState] = React.useState<{
+      status: boolean,
+      statusText: string,
+    }>({
+      status: false,
+      statusText: '',
+    });
 
   const handleAddIgnoredDomain = React.useCallback(() => {
     try {
-      assertDomainIsValid(domainToIgnore);
-      setIgnoredDomains((prev) => {
-        const newIgnoredHostList = Array.from(
-          new Set([...prev, domainToIgnore])
-        );
-
-        updateSettings({
-          ignoredHosts: newIgnoredHostList,
+      const ignoredHostsList = domainToIgnore.split(',')
+      for (const host of ignoredHostsList) {
+        assertDomainIsValid(host.trim());
+        setIgnoredDomains((prev) => {
+          const newIgnoredHostList = Array.from(
+            new Set([...prev, host.trim()])
+          );
+  
+          updateSettings({
+            ignoredHosts: newIgnoredHostList,
+          });
+  
+          return newIgnoredHostList;
         });
+      }
 
-        return newIgnoredHostList;
-      });
-
+      setState((prev) => ({
+        ...prev,
+        status: false,
+        statusText: ''
+      }));
       setDomainToIgnore('');
-    } catch (_) {
-      //
+    } catch (error) {
+      const errorMessage = (error as Error)?.message;
+
+      setState((prev) => ({
+        ...prev,
+        status: true,
+        statusText: errorMessage
+      }));
     }
   }, [domainToIgnore, updateSettings]);
 
@@ -54,16 +72,20 @@ export const IgnoredDomainSetting: React.FC = () => {
   );
 
   const handleDomainToIgnoreChange = React.useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       setDomainToIgnore(e.target.value);
     },
     []
   );
 
-  const handleToggleDomainsListExpanded = React.useCallback(() => {
-    setDomainsListExpanded((prev) => !prev);
-  }, [setDomainsListExpanded]);
+  const handleKeyDown = ((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if(event.key === 'Enter') {
+      event.preventDefault();
+      handleAddIgnoredDomain()
+    }
+  })
 
+  const { status, statusText } = state;
   return (
     <div className="p-2">
       <PanelBody className="flex flex-col gap-2">
@@ -71,10 +93,11 @@ export const IgnoredDomainSetting: React.FC = () => {
         <div className="flex justify-between items-end gap-2">
           <label className="flex flex-col gap-1 w-full">
             Domain
-            <Input
-              placeholder="e.g. google.com"
+            <TextArea
+              placeholder="e.g. google.com, bing.com (comma separated)"
               value={domainToIgnore}
               onChange={handleDomainToIgnoreChange}
+              onKeyDown={handleKeyDown}
             />
           </label>
           <Button
@@ -85,15 +108,13 @@ export const IgnoredDomainSetting: React.FC = () => {
             Add
           </Button>
         </div>
+        <div className="flex justify-between items-end gap-2">
+          {status
+            && (<p className="text-red-600">{statusText}</p>)
+          }
+        </div>
         <div className="flex flex-col gap-2">
-          <a
-            href="#"
-            className="text-blue-500"
-            onClick={handleToggleDomainsListExpanded}
-          >
-            View all blacklisted domains
-          </a>
-          <div className={twMerge('hidden', isDomainsListExpanded && 'block')}>
+          <div className="block max-h-[125px] overflow-auto scroll-auto">
             {!ignoredDomains.length && (
               <p className="text-gray-500">No blacklisted domains</p>
             )}
@@ -101,7 +122,7 @@ export const IgnoredDomainSetting: React.FC = () => {
               <div key={domain} className="flex items-center gap-2">
                 <Icon
                   type={IconType.Close}
-                  className="hover:text-neutral-400 cursor-pointer"
+                  className="hover:text-[#ff1a1a] cursor-pointer text-red-600"
                   onClick={() => handleRemoveIgnoredDomain(domain)}
                 />
                 <span>{domain}</span>

--- a/src/popup/components/LimitsSetting/LimitsSetting.tsx
+++ b/src/popup/components/LimitsSetting/LimitsSetting.tsx
@@ -114,7 +114,7 @@ export const LimitsSetting: React.FC = () => {
               >
                 <Icon
                   type={IconType.Close}
-                  className="hover:text-neutral-400 cursor-pointer"
+                  className="hover:text-[#ff1a1a] cursor-pointer text-red-600"
                   onClick={() => handleLimitRemove(domain)}
                 />
                 <span className="flex-1">{domain}</span>

--- a/src/popup/components/MonthDatePicker/MonthDatePicker.tsx
+++ b/src/popup/components/MonthDatePicker/MonthDatePicker.tsx
@@ -4,23 +4,23 @@ import { Button, ButtonType } from '../../../blocks/Button';
 import { Icon, IconType } from '../../../blocks/Icon';
 import { getIsoDate } from '../../../shared/utils/dates-helper';
 
-import { WeekDatePickerProps } from './types';
+import { MonthDatePickerProps } from './types';
 
-export const WeekDatePicker: React.FC<WeekDatePickerProps> = ({
-  onWeekChange,
+export const MonthDatePicker: React.FC<MonthDatePickerProps> = ({
+  onMonthChange,
   sundayDate,
 }) => {
-  const weekStartDate = new Date();
-  weekStartDate.setDate(sundayDate.getDate() - 6);
+  const monthStartDate = new Date();
+  monthStartDate.setDate(sundayDate.getDate() - 30);
 
   const handleChangeWeekButtonClick = React.useCallback(
     (direction) => {
       const newWeekEndDate = new Date(sundayDate);
-      newWeekEndDate.setDate(sundayDate.getDate() + direction * 7);
+      newWeekEndDate.setDate(sundayDate.getDate() + direction * 30);
 
-      onWeekChange(newWeekEndDate);
+      onMonthChange(newWeekEndDate);
     },
-    [sundayDate, onWeekChange]
+    [sundayDate, onMonthChange]
   );
 
   return (
@@ -33,7 +33,7 @@ export const WeekDatePicker: React.FC<WeekDatePickerProps> = ({
         <Icon className="m-0 flex" type={IconType.LeftArrow} />
       </Button>
       <div className="break-words break-all text-sm min-w-[120px] text-center dark:text-neutral-300">
-        <span>{getIsoDate(weekStartDate)}</span>
+        <span>{getIsoDate(monthStartDate)}</span>
         <br />
         <span>{getIsoDate(sundayDate)}</span>
       </div>

--- a/src/popup/components/MonthDatePicker/types.ts
+++ b/src/popup/components/MonthDatePicker/types.ts
@@ -1,0 +1,4 @@
+export interface MonthDatePickerProps {
+  sundayDate: Date;
+  onMonthChange: (weekEndDate: Date) => void;
+}

--- a/src/popup/components/MonthlyWebsiteActivityChart/MonthlyWebsiteActivityChart.tsx
+++ b/src/popup/components/MonthlyWebsiteActivityChart/MonthlyWebsiteActivityChart.tsx
@@ -1,0 +1,129 @@
+import { Icon, IconType } from '../../../blocks/Icon';
+import { Panel, PanelHeader } from '../../../blocks/Panel';
+import {
+  get30DaysPriorDate,
+  getHoursInMs,
+  getIsoDate,
+  getTimeFromMs,
+  getTimeWithoutSeconds,
+} from '../../../shared/utils/dates-helper';
+import { useIsDarkMode } from '../../hooks/useTheme';
+import { getTotalDailyActivity } from '../../selectors/get-total-daily-activity';
+import { MonthlyWebsiteActivityChartProps } from './types';
+import * as React from 'react';
+import { Bar } from 'react-chartjs-2';
+
+const HOUR_IN_MS = getHoursInMs(1);
+
+const BAR_OPTIONS = {
+  plugins: {
+    legend: {
+      display: false,
+    },
+    tooltip: {
+      callbacks: {
+        label: (item: any) => {
+          return (
+            ' ' + getTimeFromMs(Number(item.formattedValue || 0) * HOUR_IN_MS)
+          );
+        },
+        title: ([item]: any) => {
+          return `${item?.label}`;
+        },
+      },
+    },
+  },
+  responsive: true,
+  scales: {
+    x: {
+      ticks: {
+        color: '#222',
+      },
+    },
+    y: {
+      ticks: {
+        callback: (value: number) => {
+          return getTimeWithoutSeconds(value * HOUR_IN_MS);
+        },
+        color: '#222',
+      },
+    },
+  },
+};
+
+const DARK_MODE_BAR_OPTIONS = {
+  ...BAR_OPTIONS,
+  scales: {
+    ...BAR_OPTIONS.scales,
+    x: {
+      ...BAR_OPTIONS.scales.x,
+      grid: {
+        color: '#444444',
+      },
+      ticks: {
+        ...BAR_OPTIONS.scales.x.ticks,
+        color: '#e5e5e5',
+      },
+    },
+    y: {
+      ...BAR_OPTIONS.scales.y,
+      grid: {
+        color: '#444444',
+      },
+      ticks: {
+        ...BAR_OPTIONS.scales.y.ticks,
+        color: '#e5e5e5',
+      },
+    },
+  },
+};
+
+export const MonthlyWebsiteActivityChart: React.FC<
+  MonthlyWebsiteActivityChartProps
+> = ({ store, sundayDate, presentChartTitle }) => {
+  const isDarkMode = useIsDarkMode();
+
+  const [labels, data] = React.useMemo(() => {
+    const month = get30DaysPriorDate(sundayDate).reverse();
+    const labels = month.map((date) => getIsoDate(date));
+    const data = month.map(
+      (date) => getTotalDailyActivity(store, date) / HOUR_IN_MS,
+    );
+
+    return [labels, data];
+  }, [store, sundayDate]);
+
+  const monthName = React.useMemo(
+    () => `${labels[0]} - ${labels[labels.length - 1]}`,
+    [labels],
+  );
+
+  const chartData = React.useMemo(
+    () => ({
+      datasets: [
+        {
+          backgroundColor: '#4b76e3',
+          borderRadius: 12,
+          borderSkipped: false,
+          data: data,
+          label: 'Monthly activity',
+        },
+      ],
+      labels: labels,
+    }),
+    [labels, data],
+  );
+
+  return (
+    <Panel>
+      <PanelHeader>
+        <Icon type={IconType.ChartHistogram} />
+        {presentChartTitle?.(monthName) ?? monthName}
+      </PanelHeader>
+      <Bar
+        options={isDarkMode ? DARK_MODE_BAR_OPTIONS : BAR_OPTIONS}
+        data={chartData}
+      />
+    </Panel>
+  );
+};

--- a/src/popup/components/MonthlyWebsiteActivityChart/types.ts
+++ b/src/popup/components/MonthlyWebsiteActivityChart/types.ts
@@ -1,0 +1,7 @@
+import { TimeStore } from '../../hooks/useTimeStore';
+
+export interface MonthlyWebsiteActivityChartProps {
+  store: TimeStore;
+  sundayDate: Date;
+  presentChartTitle?: (weekName: string) => string;
+}

--- a/src/popup/components/OverallActivityCalendar/OverallActivtyCalendar.tsx
+++ b/src/popup/components/OverallActivityCalendar/OverallActivtyCalendar.tsx
@@ -34,7 +34,7 @@ export const OverallActivityCalendarPanel: React.FC<OverallActivityCalendarProps
       <Panel>
         <PanelHeader>
           <Icon type={IconType.CalendarClock} />
-          Overall Activity
+          Overall Activity <span className='text-xs'> (Your overall activity timeline.)</span>
         </PanelHeader>
         <PanelBody className="min-h-[115px]">
           <GithubCalendarWrapper

--- a/src/popup/components/ThemeSelector/index.tsx
+++ b/src/popup/components/ThemeSelector/index.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { twMerge } from 'tailwind-merge';
 
-import { Button } from '../../../blocks/Button';
+import { Button, ButtonType } from '../../../blocks/Button';
 import { Icon, IconType } from '../../../blocks/Icon';
 import { getAppTheme, setAppTheme } from '../../hooks/useTheme';
+import { Panel, PanelBody, PanelHeader } from '../../../blocks/Panel';
 
 export const ThemeSelector: React.FC = () => {
   const [theme, setTheme] = React.useState(getAppTheme());
@@ -28,38 +28,36 @@ export const ThemeSelector: React.FC = () => {
     handleThemeChange('auto');
   }, [handleThemeChange]);
 
+  console.log(theme)
   return (
-    <div className="flex flex-col gap-2">
-      <h3>Theme</h3>
-      <div className="flex flex-row rounded-lg border-2 border-solid border-neutral-300 dark:border-neutral-900 overflow-hidden">
-        <Button
-          onClick={handleAutoThemeSelect}
-          className={twMerge(
-            'flex-1 rounded-none',
-            theme === 'auto' && 'bg-neutral-300 dark:bg-neutral-900'
-          )}
-        >
-          <Icon type={IconType.Eclipse} /> Auto
-        </Button>
-        <Button
-          onClick={handleDarkThemeSelect}
-          className={twMerge(
-            'flex-1 rounded-none border-l-2 border-r-2 border-solid border-neutral-300 dark:border-neutral-900',
-            theme === 'dark' && 'bg-neutral-300 dark:bg-neutral-900'
-          )}
-        >
-          <Icon type={IconType.Moon} /> Dark
-        </Button>
-        <Button
-          onClick={handleLightThemeSelect}
-          className={twMerge(
-            'flex-1 rounded-none',
-            theme === 'light' && 'bg-neutral-300 dark:bg-neutral-900'
-          )}
-        >
-          <Icon type={IconType.Sun} /> Light
-        </Button>
-      </div>
-    </div>
+    <Panel>
+      <PanelHeader>Change Theme</PanelHeader>
+      <PanelBody className="flex flex-col gap-2">
+        <p>You can change your extension theme from here.</p>
+        <div className="flex justify-between items-end gap-2">
+          <Button
+            className="h-fit py-2 px-4 border-2 border-solid border-transparent"
+            buttonType={ButtonType.Primary}
+            onClick={handleAutoThemeSelect}
+          >
+            <Icon type={IconType.Eclipse} /> Auto
+          </Button>
+          <Button
+            className="h-fit py-2 px-4 border-2 border-solid border-transparent"
+            buttonType={ButtonType.Primary}
+            onClick={handleDarkThemeSelect}
+          >
+            <Icon type={IconType.Moon} /> Dark
+          </Button>
+          <Button
+            className="h-fit py-2 px-4 border-2 border-solid border-transparent"
+            buttonType={ButtonType.Primary}
+            onClick={handleLightThemeSelect}
+          >
+            <Icon type={IconType.Sun} /> Light
+          </Button>
+        </div>
+      </PanelBody>
+    </Panel>
   );
 };

--- a/src/popup/components/WebsiteActivityTable/WebsiteActivityTable.tsx
+++ b/src/popup/components/WebsiteActivityTable/WebsiteActivityTable.tsx
@@ -60,7 +60,7 @@ const WebsiteActivityTableFC: React.FC<ActivityTableProps> = ({
             Click on the website name to view stats for this website.
           </p>
           <p className="dark:text-neutral-300">
-            Click on the <Icon className="m-0" type={IconType.Close} /> icon to
+            Click on the <Icon className="m-0 text-red-600" type={IconType.Close} /> icon to
             hide and ignore this website.
           </p>
           <p>You can always add it in the Ignored domains section.</p>
@@ -73,7 +73,7 @@ const WebsiteActivityTableFC: React.FC<ActivityTableProps> = ({
             >
               <Icon
                 type={IconType.Close}
-                className="hover:text-neutral-400 cursor-pointer"
+                className="hover:text-[#ff1a1a] cursor-pointer text-red-600"
                 onClick={() => handleHideDomainClick(domain)}
               />
               <a

--- a/src/popup/components/WhitelistDomainsSetting/WhitelistDomainSetting.tsx
+++ b/src/popup/components/WhitelistDomainsSetting/WhitelistDomainSetting.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { twMerge } from 'tailwind-merge';
+// import { twMerge } from 'tailwind-merge';
 
 import { Button, ButtonType } from '../../../blocks/Button';
 import { Icon, IconType } from '../../../blocks/Icon';
-import { Input } from '../../../blocks/Input';
+import { TextArea } from '../../../blocks/Input';
 import { PanelBody } from '../../../blocks/Panel';
 import { assertDomainIsValid } from '../../../shared/utils/domains';
 import { usePopupContext } from '../../hooks/PopupContext';
@@ -14,27 +14,46 @@ export const WhitelistDomainSetting: React.FC = () => {
     settings.allowedHosts ?? []
   );
   const [ newAllowedHost, setNewAllowedHost] = React.useState<string>('');
-  const [isAllowedHostsListExpanded, setAllowedHostListExpanded] =
-    React.useState<boolean>(false);
+  const [state, setState] = React.useState<{
+    status: boolean,
+    statusText: string,
+  }>({
+    status: false,
+    statusText: '',
+  });
 
   const handleAddWhitelistDomain = React.useCallback(() => {
     try {
-      assertDomainIsValid(newAllowedHost);
-      setAllowedHosts((prev) => {
-        const newAllowedHostList = Array.from(
-          new Set([...prev, newAllowedHost])
-        );
-
-        updateSettings({
-          allowedHosts: newAllowedHostList,
+      const allowedHostsList = newAllowedHost.split(',')
+      for (const host of allowedHostsList) {
+        assertDomainIsValid(host.trim());
+        setAllowedHosts((prev) => {
+          const newAllowedHostList = Array.from(
+            new Set([...prev, host.trim()])
+          );
+  
+          updateSettings({
+            allowedHosts: newAllowedHostList,
+          });
+  
+          return newAllowedHostList;
         });
-
-        return newAllowedHostList;
-      });
+      }
 
       setNewAllowedHost('');
-    } catch (_) {
-      //
+      setState((prev) => ({
+        ...prev,
+        status: false,
+        statusText: ''
+      }));
+    } catch (error) {
+      const errorMessage = (error as Error)?.message;
+
+      setState((prev) => ({
+        ...prev,
+        status: true,
+        statusText: errorMessage
+      }));
     }
   }, [newAllowedHost, updateSettings]);
 
@@ -54,16 +73,20 @@ export const WhitelistDomainSetting: React.FC = () => {
   );
 
   const handleAddtoAllowedHostChange = React.useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       setNewAllowedHost(e.target.value);
     },
     []
   );
 
-  const handleAllowHostsListExpanded = React.useCallback(() => {
-    setAllowedHostListExpanded((prev) => !prev);
-  }, [setAllowedHostListExpanded]);
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if(event.key === 'Enter') {
+      event.preventDefault();
+      handleAddWhitelistDomain()
+    }
+  }
 
+  const { status, statusText } = state;
   return (
     <div className="p-2">
       <PanelBody className="flex flex-col gap-2">
@@ -71,10 +94,11 @@ export const WhitelistDomainSetting: React.FC = () => {
         <div className="flex justify-between items-end gap-2">
           <label className="flex flex-col gap-1 w-full">
             Domain
-            <Input
-              placeholder="e.g. google.com"
+            <TextArea
+              placeholder="e.g. google.com, bing.com (comma separated)"
               value={newAllowedHost}
               onChange={handleAddtoAllowedHostChange}
+              onKeyDown={handleKeyDown}
             />
           </label>
           <Button
@@ -85,15 +109,13 @@ export const WhitelistDomainSetting: React.FC = () => {
             Add
           </Button>
         </div>
+        <div className="flex justify-between items-end gap-2">
+          {status
+            && (<p className="text-red-600">{statusText}</p>)
+          }
+        </div>
         <div className="flex flex-col gap-2">
-          <a
-            href="#"
-            className="text-blue-500"
-            onClick={handleAllowHostsListExpanded}
-          >
-            View all whitelisted domains
-          </a>
-          <div className={twMerge('hidden', isAllowedHostsListExpanded && 'block')}>
+          <div className="block max-h-[125px] overflow-auto scroll-auto">
             {!allowedHosts.length && (
               <p className="text-gray-500">No whitelisted domains</p>
             )}
@@ -101,7 +123,7 @@ export const WhitelistDomainSetting: React.FC = () => {
               <div key={domain} className="flex items-center gap-2">
                 <Icon
                   type={IconType.Close}
-                  className="hover:text-neutral-400 cursor-pointer"
+                  className="hover:text-[#ff1a1a] cursor-pointer text-red-600"
                   onClick={() => handleRemoveAllowedHost(domain)}
                 />
                 <span>{domain}</span>

--- a/src/popup/pages/ActivityPage.tsx
+++ b/src/popup/pages/ActivityPage.tsx
@@ -12,6 +12,8 @@ import { DailyActivityTab } from '../components/ActivityPageDailyActivityTab/Act
 import { ActivityPageWeeklyActivityTab } from '../components/ActivityPageWeeklyActivityTab/ActivityPageWeeklyActivityTab';
 import { WeekDatePicker } from '../components/WeekDatePicker/WeekDatePicker';
 import { usePopupContext } from '../hooks/PopupContext';
+import { MonthDatePicker } from '../components/MonthDatePicker/MonthDatePicker';
+import { ActivityPageMonthlyActivityTab } from '../components/ActivityPageMonthlyActivityTab/ActivityPageMonthlyActivityTab';
 
 interface ActivityPageProps {
   date?: string;
@@ -20,6 +22,7 @@ interface ActivityPageProps {
 enum ActivityPageTabs {
   Daily,
   Weekly,
+  Monthly
 }
 
 export const ActivityPage: React.FC<ActivityPageProps> = ({
@@ -46,6 +49,7 @@ export const ActivityPage: React.FC<ActivityPageProps> = ({
           buttonType={
             activeTab === value ? ButtonType.Primary : ButtonType.Secondary
           }
+          className='px-2'
           onClick={() => setActiveTab(value)}
           key={key}
         >
@@ -71,6 +75,12 @@ export const ActivityPage: React.FC<ActivityPageProps> = ({
             onWeekChange={setPickedSunday}
           />
         )}
+        {activeTab === ActivityPageTabs.Monthly && (
+          <MonthDatePicker
+            sundayDate={pickedSunday}
+            onMonthChange={setPickedSunday}
+          />
+        )}
       </Panel>
 
       {activeTab === ActivityPageTabs.Daily && (
@@ -79,6 +89,12 @@ export const ActivityPage: React.FC<ActivityPageProps> = ({
 
       {activeTab === ActivityPageTabs.Weekly && (
         <ActivityPageWeeklyActivityTab
+          store={store}
+          sundayDate={pickedSunday}
+        />
+      )}
+      {activeTab === ActivityPageTabs.Monthly && (
+        <ActivityPageMonthlyActivityTab
           store={store}
           sundayDate={pickedSunday}
         />

--- a/src/popup/pages/OverallPage.tsx
+++ b/src/popup/pages/OverallPage.tsx
@@ -54,6 +54,7 @@ export const OverallPage: React.FC<OverallPageProps> = ({
         activityTimeline={timelineEvents}
         filteredHostname={null}
         emptyHoursMarginCount={0}
+        description="Your web activity in last 6 hours."
       />
     </div>
   );

--- a/src/popup/pages/PreferencesPage.tsx
+++ b/src/popup/pages/PreferencesPage.tsx
@@ -8,6 +8,7 @@ import { Input } from './../../blocks/Input';
 import {IgnoredDomainSetting} from '../components/IgnoredDomainsSetting/IgnoredDomainSetting';
 import { WhitelistDomainSetting } from '../components/WhitelistDomainsSetting/WhitelistDomainSetting';
 import {UserTokenSetting} from "../components/UserTokenSetting/UserTokenSetting";
+import { ThemeSelector } from '../components/ThemeSelector';
 
 export const PreferencesPage: FC = () => {
     const [isWhitelistShown, hideWhitelist] = React.useState<boolean>(true);
@@ -45,6 +46,7 @@ export const PreferencesPage: FC = () => {
                     {(isWhitelistShown ? <WhitelistDomainSetting />: <IgnoredDomainSetting />)}
                  </PanelBody>
             </Panel>
+            <ThemeSelector />
         </div>
     );
 };

--- a/src/popup/selectors/get-total-monthly-activity.ts
+++ b/src/popup/selectors/get-total-monthly-activity.ts
@@ -1,0 +1,10 @@
+import { get30DaysPriorDate } from '../../shared/utils/dates-helper';
+
+import { TimeStore } from '../hooks/useTimeStore';
+
+import { getTotalDailyActivity } from './get-total-daily-activity';
+
+export const getTotalMonthlyActivity = (store: TimeStore, date = new Date()) =>
+  get30DaysPriorDate(date).reduce((sum, date) => {
+    return sum + getTotalDailyActivity(store, date);
+  }, 0);

--- a/src/shared/utils/dates-helper.ts
+++ b/src/shared/utils/dates-helper.ts
@@ -61,6 +61,22 @@ export const get7DaysPriorDate = <
   });
 };
 
+export const get30DaysPriorDate = <
+  T extends (date: Date) => any = (date: Date) => Date
+>(
+  date: Date,
+  map?: T
+): ReturnType<T>[] => {
+  const defaultMap = (date: Date) => new Date(date);
+  const monthEndDate = new Date(date);
+
+  return new Array(30).fill(0).map((_, index) => {
+    monthEndDate.setDate(monthEndDate.getDate() - Number(index > 0));
+
+    return map?.(monthEndDate) ?? defaultMap(monthEndDate);
+  });
+};
+
 export const getDatesWeekSundayDate = (date: Date = new Date()) => {
   date.setDate(date.getDate() + date.getDay());
 


### PR DESCRIPTION
Issue: #26 and #31 (Both are related and UI issues, hence clubbed together)

Changes:
- The color scheme of the Overall Activity has been improved and also a legend has been added for more clarification.
![{6A28E8DF-3E96-444F-8DC9-6A846B9BC95C}](https://github.com/user-attachments/assets/d4db4a68-88e8-4b5c-9ccc-bf834ec3656e)
- Some help texts have been added to make the user understand the sections more clearly 
![{36DA16B7-7029-4D46-A93E-9B5A9FFD37C2}](https://github.com/user-attachments/assets/451f15aa-f4d3-4677-8766-16a52fb84e8b)
- A monthly section has been added in the Details page
![{1F84019F-7694-4F20-836F-581DF10CB175}](https://github.com/user-attachments/assets/fdeec00b-de62-484a-b074-45701ee91954)
- The color scheme of the delete buttons have been changed to make it more clear to the users
![{897E0ACF-A204-4EB7-A471-423B9FE8C338}](https://github.com/user-attachments/assets/a9e75649-9648-4bab-9dde-d3916b7072ec)
- The Whitelist and Blacklist sections have been overhauled. The text input box can take comma separated values.
![{51258030-668C-4A08-8ED0-81B51A6279B8}](https://github.com/user-attachments/assets/6150e334-bad6-40ca-b69b-48fbe682da34)
- Validations has been added for Whitelist and Blacklist sections
![{166D1E21-4C45-4544-A866-ECDBB94FC7AB}](https://github.com/user-attachments/assets/2b045c15-f706-42ef-81ba-d8e68c9cabe0)
- The list has been given a fixed height and post that the overflow is made scrollable.
![{D97B7F65-E085-4A56-995F-0553B40DA81D}](https://github.com/user-attachments/assets/44340bbc-6a0b-43cb-9e59-555e0530d916)
- Pressing enter also creates Blacklist and whitelist entries.
- There was an error where the final time was shown in negative, that has been resolved.
![{A51A2D4E-A1DE-4ECC-B4ED-F04937688CE1}](https://github.com/user-attachments/assets/1978c86b-817d-4f9d-b63c-a13980796fb6)

- Codealike logo and name on same line now along with the User status. Codealike name has been made bold.
![image](https://github.com/user-attachments/assets/e7e0528f-4579-46c8-8963-3afb68054f60)

